### PR TITLE
[FIX] partner_event: Update event.registration records without permis…

### DIFF
--- a/partner_event/models/res_partner.py
+++ b/partner_event/models/res_partner.py
@@ -17,6 +17,7 @@ class ResPartner(models.Model):
     event_count = fields.Integer(
         string='Events',
         compute='_compute_event_count',
+        compute_sudo=True,
         help="Count of events with confirmed registrations.",
     )
     registration_count = fields.Integer(
@@ -52,5 +53,5 @@ class ResPartner(models.Model):
     @api.multi
     def write(self, data):
         res = super(ResPartner, self).write(data)
-        self.mapped('registrations').partner_data_update(data)
+        self.sudo().mapped('registrations').partner_data_update(data)
         return res

--- a/partner_event/tests/test_event_registration.py
+++ b/partner_event/tests/test_event_registration.py
@@ -16,6 +16,8 @@ class TestEventRegistration(common.SavepointCase):
     @classmethod
     def setUpClass(cls):
         super(TestEventRegistration, cls).setUpClass()
+        cls.demo_user = cls.env.ref("base.user_demo")
+        cls.demo_user.groups_id -= cls.env.ref("event.group_event_user")
         cls.event_0 = cls.env['event.event'].create({
             'name': 'Test event',
             'date_begin': fields.Datetime.now(),
@@ -31,7 +33,7 @@ class TestEventRegistration(common.SavepointCase):
         cls.partner_01 = partner_model.create({
             'name': 'Test Partner 01',
             'email': 'email01@test.com'
-        })
+        }).sudo(cls.demo_user)
         cls.registration_01 = registration_model.create({
             'email': 'email01@test.com', 'event_id': cls.event_0.id})
         cls.registration_02 = registration_model.create({


### PR DESCRIPTION
…sions (#111)

If a given user has no permission to access `event.registration` records, he becomes unable to read or write some `res.partner` fields.

Now that process uses `sudo` and is tested to work fine.